### PR TITLE
Fix auto language

### DIFF
--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -85,6 +85,7 @@ func (e *Engine) Transcript() error {
 	if err != nil {
 		return err
 	}
+	defer e.model.Close()
 
 	// Decode the WAV file - load the full buffer
 	dec := wav.NewDecoder(fh)
@@ -109,7 +110,7 @@ func (e *Engine) Transcript() error {
 
 	log.Info().Msgf("%s", e.ctx.SystemInfo())
 
-	if e.cfg.Language != "" && e.cfg.Language != "auto"{
+	if e.cfg.Language != "" && e.cfg.Language != "auto" {
 		_ = e.ctx.SetLanguage(e.cfg.Language)
 	}
 

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -109,7 +109,7 @@ func (e *Engine) Transcript() error {
 
 	log.Info().Msgf("%s", e.ctx.SystemInfo())
 
-	if e.cfg.Language != "" {
+	if e.cfg.Language != "" && e.cfg.Language != "auto"{
 		_ = e.ctx.SetLanguage(e.cfg.Language)
 	}
 


### PR DESCRIPTION

In Whisper, the "language auto" option can significantly slow down the execution when using the ggml-large.bin model. This is evident when benchmarking a 10-second video with whisper.cpp:

With "language auto" set, the processing time is 423803.19 ms.
When the language is explicitly set to "zh", the processing time is reduced to 163633.48 ms.
This behavior is demonstrated in the example provided here: https://github.com/ggerganov/whisper.cpp/blob/master/bindings/go/examples/go-whisper/flags.go#L96

However, I'm currently facing an issue where the go-whisper command hangs, and I'm unable to resolve this problem.