### PR TITLE
feat: add prompt functionality to Whisper engine

### DIFF
--- a/config/whisper.go
+++ b/config/whisper.go
@@ -11,6 +11,7 @@ type Whisper struct {
 	Debug     bool
 	SpeedUp   bool
 	Translate bool
+	Prompt    string
 
 	PrintProgress bool
 	PrintSegment  bool

--- a/go.mod
+++ b/go.mod
@@ -35,4 +35,4 @@ require (
 	golang.org/x/text v0.11.0 // indirect
 )
 
-replace github.com/ggerganov/whisper.cpp/bindings/go => github.com/appleboy/whisper.cpp/bindings/go v0.0.0-20230705021339-6225a2d8ea26
+replace github.com/ggerganov/whisper.cpp/bindings/go => github.com/appleboy/whisper.cpp/bindings/go v0.0.0-20230808024901-03650882d33b

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1o
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
-github.com/appleboy/whisper.cpp/bindings/go v0.0.0-20230705021339-6225a2d8ea26 h1:lGy5BiuHUfKzqiQBk9cmZxwPvfhx2z5qU4kYrMaIQ90=
-github.com/appleboy/whisper.cpp/bindings/go v0.0.0-20230705021339-6225a2d8ea26/go.mod h1:QIjZ9OktHFG7p+/m3sMvrAJKKdWrr1fZIK0rM6HZlyo=
+github.com/appleboy/whisper.cpp/bindings/go v0.0.0-20230808024901-03650882d33b h1:gH2gPwntm+POnKe4lCYxgKWHqqFwd2Xs2HiUFJcC2OU=
+github.com/appleboy/whisper.cpp/bindings/go v0.0.0-20230808024901-03650882d33b/go.mod h1:QIjZ9OktHFG7p+/m3sMvrAJKKdWrr1fZIK0rM6HZlyo=
 github.com/bitly/go-simplejson v0.5.1 h1:xgwPbetQScXt1gh9BmoJ6j9JMr3TElvuIyjR8pgdoow=
 github.com/bitly/go-simplejson v0.5.1/go.mod h1:YOPVLzCfwK14b4Sff3oP1AmGhI9T9Vsg84etUnlyp+Q=
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=

--- a/main.go
+++ b/main.go
@@ -148,6 +148,11 @@ func main() {
 			Usage:   "youtube insecure",
 			EnvVars: []string{"PLUGIN_YOUTUBE_INSECURE", "INPUT_YOUTUBE_INSECURE"},
 		},
+		&cli.StringFlag{
+			Name:    "prompt",
+			Usage:   "prompt",
+			EnvVars: []string{"PLUGIN_PROMPT", "INPUT_PROMPT"},
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -166,6 +171,7 @@ func run(c *cli.Context) error {
 			Translate:     c.Bool("translate"),
 			PrintProgress: c.Bool("print-progress"),
 			PrintSegment:  c.Bool("print-segment"),
+			Prompt:        c.String("prompt"),
 
 			OutputFolder:   c.String("output-folder"),
 			OutputFormat:   c.StringSlice("output-format"),

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -107,6 +107,7 @@ func (e *Engine) Transcript() error {
 	e.ctx.SetThreads(e.cfg.Threads)
 	e.ctx.SetSpeedup(e.cfg.SpeedUp)
 	e.ctx.SetTranslate(e.cfg.Translate)
+	e.ctx.SetPrompt(e.cfg.Prompt)
 
 	log.Info().Msgf("%s", e.ctx.SystemInfo())
 


### PR DESCRIPTION
- Add a new field `Prompt` to the `Whisper` struct in `config/whisper.go`
- Add a new flag `prompt` to the command line interface in `main.go`
- Set the `Prompt` field of the `Engine` struct in `whisper/whisper.go`