### PR TITLE
improve youtube video download reliability

### DIFF
--- a/youtube/youtube.go
+++ b/youtube/youtube.go
@@ -24,6 +24,7 @@ import (
 type Engine struct {
 	cfg   *config.Youtube
 	video *youtube.Video
+	retry int
 }
 
 // Filename returns a sanitized filename.
@@ -105,16 +106,34 @@ func (e *Engine) Download(ctx context.Context) (string, error) {
 	}
 
 	outputFile := path.Join(folder, "video.3gp")
-	if err := downloader.Download(context.Background(), e.video, format, outputFile); err != nil {
-		return "", err
+
+	i := 0
+	// limit 20
+	for i < e.retry {
+		if err := downloader.Download(context.Background(), e.video, format, outputFile); err != nil {
+			return "", err
+		}
+		if isFileExistsAndNotEmpty(outputFile) {
+			return outputFile, nil
+		}
+		i++
 	}
 
-	return outputFile, nil
+	return "", errors.New("youtube video can't download")
 }
 
 // New for creating a new youtube engine.
 func New(cfg *config.Youtube) (*Engine, error) {
 	return &Engine{
-		cfg: cfg,
+		cfg:   cfg,
+		retry: 20,
 	}, nil
+}
+
+func isFileExistsAndNotEmpty(name string) bool {
+	fileInfo, err := os.Stat(name)
+	if err != nil {
+		return false
+	}
+	return fileInfo.Size() > 0
 }

--- a/youtube/youtube.go
+++ b/youtube/youtube.go
@@ -130,6 +130,7 @@ func New(cfg *config.Youtube) (*Engine, error) {
 	}, nil
 }
 
+// isFileExistsAndNotEmpty check file not zero byte file
 func isFileExistsAndNotEmpty(name string) bool {
 	fileInfo, err := os.Stat(name)
 	if err != nil {


### PR DESCRIPTION
Following an update to YouTube's API policy, attempts to download videos now result in a 403 HTTP status code. To ensure video reliability, implemented a retry mechanism