### PR TITLE
chore(audio): remove silence cutting from transcription process

### DIFF
--- a/config/whisper.go
+++ b/config/whisper.go
@@ -18,7 +18,6 @@ type Whisper struct {
 
 	PrintProgress bool
 	PrintSegment  bool
-	CutSilences   bool
 
 	OutputFolder   string
 	OutputFilename string

--- a/main.go
+++ b/main.go
@@ -159,11 +159,6 @@ func main() {
 			Usage:   "initial prompt",
 			EnvVars: []string{"PLUGIN_PROMPT", "INPUT_PROMPT"},
 		},
-		// &cli.BoolFlag{
-		// 	Name:    "cut-silences",
-		// 	Usage:   "cut silences",
-		// 	EnvVars: []string{"PLUGIN_CUT_SILENCES", "INPUT_CUT_SILENCES"},
-		// },
 		&cli.UintFlag{
 			Name:    "max-context",
 			Usage:   "maximum number of text context tokens to store",
@@ -206,7 +201,6 @@ func run(c *cli.Context) error {
 
 			PrintProgress: c.Bool("print-progress"),
 			PrintSegment:  c.Bool("print-segment"),
-			CutSilences:   c.Bool("cut-silences"),
 
 			OutputFolder:   c.String("output-folder"),
 			OutputFilename: c.String("output-filename"),

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -66,19 +66,9 @@ func (e *Engine) Transcript() error {
 	}
 	defer os.RemoveAll(dir)
 
-	ext := filepath.Ext(e.cfg.AudioPath)
-	cutSilencesPath := filepath.Join(dir, "cut_silences"+ext)
 	convertedPath := filepath.Join(dir, "converted.wav")
 	sourcePath := e.cfg.AudioPath
 	outputPath := ""
-
-	if e.cfg.CutSilences {
-		log.Debug().Msg("start cut silences from audio")
-		if err := cutSilences(sourcePath, cutSilencesPath); err != nil {
-			return err
-		}
-		sourcePath = cutSilencesPath
-	}
 
 	log.Debug().Msg("start convert audio to wav")
 	if err := audioToWav(sourcePath, convertedPath); err != nil {


### PR DESCRIPTION
- Remove the `CutSilences` configuration option
- Delete commented-out code related to the `cut-silences` CLI flag
- Remove code handling audio silence cutting in the transcription process